### PR TITLE
Improve check for missing top level decls

### DIFF
--- a/lib/Besra/SA/Types.hs
+++ b/lib/Besra/SA/Types.hs
@@ -18,6 +18,7 @@ import Besra.Types.Ann
 
 type Decl' = IR1.Decl Parsed
 type Binding' = IR1.Binding Parsed
+type TypeAnn' = IR1.TypeAnn Parsed
 
 data ConflictingTypeAnnDecl
   = ConflictingTypeAnnDecl FilePath [Decl']
@@ -32,10 +33,10 @@ data ConflictingArgCounts
   = ConflictingArgCounts FilePath [Binding']
 
 data MissingTopLevelTypeAnnDecl
-  = MissingTopLevelTypeAnnDecl FilePath Decl'
+  = MissingTopLevelTypeAnnDecl FilePath Binding'
 
 data MissingTopLevelBindingDecl
-  = MissingTopLevelBindingDecl FilePath Decl'
+  = MissingTopLevelBindingDecl FilePath TypeAnn'
 
 data SAError
   = ConflictingTypeAnnDeclErr ConflictingTypeAnnDecl


### PR DESCRIPTION
This makes one of the SA checks less strict to accept the following:
```idris
x : Int
y : String
x = 3
y = "abc"
```